### PR TITLE
add centos8 build

### DIFF
--- a/centos/8/Dockerfile
+++ b/centos/8/Dockerfile
@@ -1,0 +1,40 @@
+# Copyright 2015-2016 jitakirin
+#
+# This file is part of docker-rpmbuild.
+#
+# docker-rpmbuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# docker-rpmbuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with docker-rpmbuild.  If not, see <http://www.gnu.org/licenses/>.
+
+# Based on: http://fedoraproject.org/wiki/How_to_create_an_RPM_package
+# And also:
+# - https://registry.hub.docker.com/u/nishigori/rpmbuild
+# - https://registry.hub.docker.com/u/sydneyuni/rpm-build-env/
+#
+# I have forked https://github.com/jitakirin/docker-rpmbuild and modified
+# for my own purposes.
+
+FROM centos:8
+
+RUN yum install -y rpmdevtools rpm-sign expect yum-utils gpg createrepo_c && \
+    yum clean all && \
+    rm -r -f /var/cache/*
+COPY docker-init.sh docker-rpm-build.sh docker-rpm-sign.sh docker-rpm-verify.sh docker-rpm-import.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-*.sh
+ADD keys /keys
+
+RUN useradd rpmbuild
+USER rpmbuild
+RUN rpmdev-setuptree
+USER root
+
+ENTRYPOINT ["/usr/local/bin/docker-init.sh"]

--- a/centos/8/rpmbuilder-c8.bats
+++ b/centos/8/rpmbuilder-c8.bats
@@ -1,0 +1,11 @@
+#!/usr/bin/env bats
+#setup() {
+#    docker pull "atsuio/rpmbuilder:centos8" >&2
+#}
+
+@test "centos 8 version is correct" {
+  run docker run --entrypoint "cat" "atsuio/rpmbuilder:centos8" /etc/os-release
+  [ $status -eq 0 ]
+  [ "${lines[0]}" = 'NAME="CentOS Linux"' ]
+  [ "${lines[1]}" = 'VERSION="8 (Core)"' ]
+}

--- a/centos/Makefile
+++ b/centos/Makefile
@@ -6,6 +6,7 @@ LATEST := $(IMAGE_NAME):latest
 build: keys
 	docker build -t $(IMAGE_NAME):centos6 -f 6/Dockerfile .
 	docker build -t $(IMAGE_NAME):centos7 -t $(LATEST) -f 7/Dockerfile .
+	docker build -t $(IMAGE_NAME):centos8 -f 8/Dockerfile .
 
 keys:
 	mkdir -p keys
@@ -15,6 +16,7 @@ keys:
 push:
 	docker push $(IMAGE_NAME):centos6
 	docker push $(IMAGE_NAME):centos7
+	docker push $(IMAGE_NAME):centos8
 	docker push $(LATEST)
 
 clean:


### PR DESCRIPTION
Create build files and docker images for centos8.

This works-for-me(tm), as I rebuilt the rsnapshot rpm in this container, just perfectly.

I did NOT move `latest` to be `centos8`.